### PR TITLE
Fix quiet flag not working when using rez env

### DIFF
--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -134,7 +134,7 @@ class CMD(Shell):
                     # /C the "rez env" is applied and then immediately lost
                     # when the child process returns and then the cmd
                     # also returns in succession
-                    ex.command("cmd /Q /K rez context")
+                    ex.command("cmd /Q /C rez context")
 
         def _create_ex():
             return RexExecutor(interpreter=self.new_shell(),
@@ -156,7 +156,6 @@ class CMD(Shell):
 
         if shell_command:
             executor.command(shell_command)
-        executor.command('exit %errorlevel%')
 
         code = executor.get_output()
         target_file = os.path.join(tmpdir, "rez-shell.%s"


### PR DESCRIPTION
Closing the context shell right away but leaving the actual environment shell open. The behavior before was leaving the context shell (showing the current context) open but closed the environment shell right away. This resulted in the quiet flag not resolving a proper environment because the environment shell was exited.